### PR TITLE
LFLT-284 SEO description length in database might be short

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.8.0-dev</version>
+        <version>1.8.1-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet</artifactId>
-        <version>1.8.0-dev</version>
+        <version>1.8.1-dev</version>
     </parent>
     
     <artifactId>leaflet-persistence</artifactId>

--- a/persistence/src/main/java/hu/psprog/leaflet/persistence/entity/Document.java
+++ b/persistence/src/main/java/hu/psprog/leaflet/persistence/entity/Document.java
@@ -45,7 +45,7 @@ public class Document extends SelfStatusAwareIdentifiableEntity<Long> {
     @Column(name = DatabaseConstants.COLUMN_SEO_TITLE)
     private String seoTitle;
 
-    @Column(name = DatabaseConstants.COLUMN_SEO_DESCRIPTION)
+    @Column(name = DatabaseConstants.COLUMN_SEO_DESCRIPTION, length = 4095)
     private String seoDescription;
 
     @Column(name = DatabaseConstants.COLUMN_SEO_KEYWORDS)

--- a/persistence/src/main/java/hu/psprog/leaflet/persistence/entity/Entry.java
+++ b/persistence/src/main/java/hu/psprog/leaflet/persistence/entity/Entry.java
@@ -81,7 +81,7 @@ public class Entry extends SelfStatusAwareIdentifiableEntity<Long> {
     @Column(name = DatabaseConstants.COLUMN_SEO_TITLE)
     private String seoTitle;
 
-    @Column(name = DatabaseConstants.COLUMN_SEO_DESCRIPTION)
+    @Column(name = DatabaseConstants.COLUMN_SEO_DESCRIPTION, length = 4095)
     private String seoDescription;
 
     @Column(name = DatabaseConstants.COLUMN_SEO_KEYWORDS)

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet</artifactId>
     <packaging>pom</packaging>
-    <version>1.8.0-dev</version>
+    <version>1.8.1-dev</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -40,7 +40,7 @@
         <java.version>11</java.version>
 
         <!-- leaflet internal dependency versions -->
-        <leaflet.rest-api.version>1.5.0</leaflet.rest-api.version>
+        <leaflet.rest-api.version>1.5.1</leaflet.rest-api.version>
         <leaflet.jwt-component.version>2.4.0</leaflet.jwt-component.version>
         <leaflet.mailer-component.version>1.2.0</leaflet.mailer-component.version>
         <leaflet.rcp.version>1.3.0</leaflet.rcp.version>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet</artifactId>
-        <version>1.8.0-dev</version>
+        <version>1.8.1-dev</version>
     </parent>
     
     <artifactId>leaflet-service</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet</artifactId>
-        <version>1.8.0-dev</version>
+        <version>1.8.1-dev</version>
     </parent>
 
     <packaging>jar</packaging>


### PR DESCRIPTION
 - Updated REST API version (fixed validation)
 - Updated length of seo_description column in Document and Entry entities to 4095 chars