### PR TITLE
LFLT-348 Implement commenting and comment handling in LCFA

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.2-dev</version>
+        <version>1.9.3-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/suites/AbstractParameterizedBaseTest.java
+++ b/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/suites/AbstractParameterizedBaseTest.java
@@ -44,6 +44,8 @@ public abstract class AbstractParameterizedBaseTest extends AbstractTransactiona
     static final String CONTROL_SUFFIX_MODIFY = "modify";
     static final String CONTROL_SUFFIX_CREATE = "create";
 
+    static final String RECAPTCHA_TOKEN = "recaptcha-token";
+
     private static final String[] DATABASE_TABLES = {
             "leaflet_dynamic_config_properties",
             "leaflet_documents",

--- a/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/suites/ContactRequestControllerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/suites/ContactRequestControllerAcceptanceTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ContactRequestControllerAcceptanceTest extends AbstractParameterizedBaseTest {
 
     private static final ContactRequestModel CONTACT_REQUEST_MODEL = new ContactRequestModel();
-    private static final String RECAPTCHA_TOKEN = "recaptcha-token";
     private static final String NAME = "name";
     private static final String EMAIL = "test@local.dev";
     private static final String MESSAGE = "contact-message";

--- a/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/suites/UsersControllerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/suites/UsersControllerAcceptanceTest.java
@@ -246,7 +246,7 @@ public class UsersControllerAcceptanceTest extends AbstractParameterizedBaseTest
         passwordResetDemandRequestModel.setEmail(TEST_USER_3_EMAIL);
 
         // when
-        userBridgeService.demandPasswordReset(passwordResetDemandRequestModel);
+        userBridgeService.demandPasswordReset(passwordResetDemandRequestModel, RECAPTCHA_TOKEN);
 
         // then
         assertThat(notificationService.getPasswordResetRequest(), notNullValue());
@@ -263,7 +263,7 @@ public class UsersControllerAcceptanceTest extends AbstractParameterizedBaseTest
         UserPasswordRequestModel userPasswordRequestModel = prepareUserPasswordRequestModel(true);
 
         // when
-        userBridgeService.confirmPasswordReset(userPasswordRequestModel);
+        userBridgeService.confirmPasswordReset(userPasswordRequestModel, RECAPTCHA_TOKEN);
 
         // then
         LoginResponseDataModel loginResponse = userBridgeService.claimToken(prepareLoginRequestModel(TEST_EDITOR_4_EMAIL, UPDATED_PASSWORD));
@@ -368,7 +368,7 @@ public class UsersControllerAcceptanceTest extends AbstractParameterizedBaseTest
         UserInitializeRequestModel userInitializeRequestModel = getControl(CONTROL_USER_REGISTER, UserInitializeRequestModel.class);
 
         // when
-        ExtendedUserDataModel result = userBridgeService.signUp(userInitializeRequestModel);
+        ExtendedUserDataModel result = userBridgeService.signUp(userInitializeRequestModel, RECAPTCHA_TOKEN);
 
         // then
         assertCreatedUser(userInitializeRequestModel, result.getId());
@@ -383,7 +383,7 @@ public class UsersControllerAcceptanceTest extends AbstractParameterizedBaseTest
         userInitializeRequestModel.setEmail(TEST_USER_1_EMAIL);
 
         // when
-        userBridgeService.signUp(userInitializeRequestModel);
+        userBridgeService.signUp(userInitializeRequestModel, RECAPTCHA_TOKEN);
 
         // then
         // exception expected
@@ -449,7 +449,7 @@ public class UsersControllerAcceptanceTest extends AbstractParameterizedBaseTest
 
         PasswordResetDemandRequestModel passwordResetDemandRequestModel = new PasswordResetDemandRequestModel();
         passwordResetDemandRequestModel.setEmail(email);
-        userBridgeService.demandPasswordReset(passwordResetDemandRequestModel);
+        userBridgeService.demandPasswordReset(passwordResetDemandRequestModel, RECAPTCHA_TOKEN);
 
         return notificationService.getPasswordResetRequest().getToken();
     }

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet</artifactId>
-        <version>1.9.2-dev</version>
+        <version>1.9.3-dev</version>
     </parent>
     
     <artifactId>leaflet-persistence</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet</artifactId>
     <packaging>pom</packaging>
-    <version>1.9.2-dev</version>
+    <version>1.9.3-dev</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -40,10 +40,10 @@
         <java.version>11</java.version>
 
         <!-- leaflet internal dependency versions -->
-        <leaflet.rest-api.version>1.6.2</leaflet.rest-api.version>
+        <leaflet.rest-api.version>1.6.3</leaflet.rest-api.version>
         <leaflet.jwt-component.version>2.4.0</leaflet.jwt-component.version>
         <leaflet.mailer-component.version>1.2.1</leaflet.mailer-component.version>
-        <leaflet.rcp.version>1.4.0</leaflet.rcp.version>
+        <leaflet.rcp.version>1.5.2</leaflet.rcp.version>
         <leaflet.bridge.version>3.2.1</leaflet.bridge.version>
         <leaflet.tlp-appender.version>1.1.0</leaflet.tlp-appender.version>
         <leaflet.translation-adapter.version>2.1.0</leaflet.translation-adapter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <leaflet.jwt-component.version>2.4.0</leaflet.jwt-component.version>
         <leaflet.mailer-component.version>1.2.1</leaflet.mailer-component.version>
         <leaflet.rcp.version>1.5.2</leaflet.rcp.version>
-        <leaflet.bridge.version>3.2.1</leaflet.bridge.version>
+        <leaflet.bridge.version>3.2.2</leaflet.bridge.version>
         <leaflet.tlp-appender.version>1.1.0</leaflet.tlp-appender.version>
         <leaflet.translation-adapter.version>2.1.0</leaflet.translation-adapter.version>
         

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet</artifactId>
-        <version>1.9.2-dev</version>
+        <version>1.9.3-dev</version>
     </parent>
     
     <artifactId>leaflet-service</artifactId>

--- a/service/src/main/java/hu/psprog/leaflet/service/CommentService.java
+++ b/service/src/main/java/hu/psprog/leaflet/service/CommentService.java
@@ -32,8 +32,7 @@ public interface CommentService extends CreateOperationCapableService<CommentVO,
      * @param entryVO {@link EntryVO} object to return comments for.
      * @return list of all comments under given entry
      */
-    EntityPageVO<CommentVO> getPageOfCommentsForEntry(int page, int limit, OrderDirection direction,
-                                                             CommentVO.OrderBy orderBy, EntryVO entryVO);
+    EntityPageVO<CommentVO> getPageOfCommentsForEntry(int page, int limit, OrderDirection direction, CommentVO.OrderBy orderBy, EntryVO entryVO);
 
     /**
      * Returns only enabled comments for given entry.
@@ -45,8 +44,7 @@ public interface CommentService extends CreateOperationCapableService<CommentVO,
      * @param entryVO {@link EntryVO} object to return comments for.
      * @return list of enabled comments under given entry
      */
-    EntityPageVO<CommentVO> getPageOfPublicCommentsForEntry(int page, int limit, OrderDirection direction,
-                                                                   CommentVO.OrderBy orderBy, EntryVO entryVO);
+    EntityPageVO<CommentVO> getPageOfPublicCommentsForEntry(int page, int limit, OrderDirection direction, CommentVO.OrderBy orderBy, EntryVO entryVO);
 
     /**
      * Returns comments created by given user.
@@ -56,10 +54,9 @@ public interface CommentService extends CreateOperationCapableService<CommentVO,
      * @param direction order direction
      * @param orderBy order by field
      * @param userVO {@link UserVO} object to return comments for.
-     * @return
+     * @return list of all comments for given user
      */
-    EntityPageVO<CommentVO> getPageOfCommentsForUser(int page, int limit, OrderDirection direction,
-                                                            CommentVO.OrderBy orderBy, UserVO userVO);
+    EntityPageVO<CommentVO> getPageOfCommentsForUser(int page, int limit, OrderDirection direction, CommentVO.OrderBy orderBy, UserVO userVO);
 
     /**
      * Sends email notification for the author of an entry under a comment has been created.

--- a/service/src/main/java/hu/psprog/leaflet/service/impl/CommentServiceImpl.java
+++ b/service/src/main/java/hu/psprog/leaflet/service/impl/CommentServiceImpl.java
@@ -93,8 +93,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @PermitEditorOrAdmin
-    public EntityPageVO<CommentVO> getPageOfCommentsForEntry(int page, int limit, OrderDirection direction,
-                                                             CommentVO.OrderBy orderBy, EntryVO entryVO) {
+    public EntityPageVO<CommentVO> getPageOfCommentsForEntry(int page, int limit, OrderDirection direction, CommentVO.OrderBy orderBy, EntryVO entryVO) {
 
         Pageable pageable = PageableUtil.createPage(page, limit, direction, orderBy.getField());
         Entry entry = entryVOToEntryConverter.convert(entryVO);
@@ -104,8 +103,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public EntityPageVO<CommentVO> getPageOfPublicCommentsForEntry(int page, int limit, OrderDirection direction,
-                                                                   CommentVO.OrderBy orderBy, EntryVO entryVO) {
+    public EntityPageVO<CommentVO> getPageOfPublicCommentsForEntry(int page, int limit, OrderDirection direction, CommentVO.OrderBy orderBy, EntryVO entryVO) {
 
         EntityPageVO<CommentVO> entityPageVO = EMPTY_ENTITY_PAGE_VO;
         if (Objects.nonNull(entryVO)) {
@@ -122,9 +120,8 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    @PermitEditorOrAdmin
-    public EntityPageVO<CommentVO> getPageOfCommentsForUser(int page, int limit, OrderDirection direction,
-                                                            CommentVO.OrderBy orderBy, UserVO userVO) {
+    @PermitSelf.UserOrModerator
+    public EntityPageVO<CommentVO> getPageOfCommentsForUser(int page, int limit, OrderDirection direction, CommentVO.OrderBy orderBy, UserVO userVO) {
 
         Pageable pageable = PageableUtil.createPage(page, limit, direction, orderBy.getField());
         User user = userVOToUserConverter.convert(userVO);

--- a/service/src/main/java/hu/psprog/leaflet/service/security/annotation/PermitSelf.java
+++ b/service/src/main/java/hu/psprog/leaflet/service/security/annotation/PermitSelf.java
@@ -29,6 +29,14 @@ public interface PermitSelf {
     }
 
     /**
+     * Permits user self-management operations, which are also available for admins to manage users (ex.: get user).
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @PreAuthorize("isAuthenticated() && hasAnyAuthority('ADMIN', 'EDITOR', 'USER') && @ownershipEvaluator.isSelfOrModerator(authentication, #userVO)")
+    @interface UserOrModerator {
+    }
+
+    /**
      * Permits entry modification for entry owners.
      * Administrator can modify other editors' entries as well.
      */

--- a/service/src/main/java/hu/psprog/leaflet/service/security/evaluator/OwnershipEvaluator.java
+++ b/service/src/main/java/hu/psprog/leaflet/service/security/evaluator/OwnershipEvaluator.java
@@ -8,6 +8,7 @@ import hu.psprog.leaflet.service.EntryService;
 import hu.psprog.leaflet.service.exception.ServiceException;
 import hu.psprog.leaflet.service.vo.CommentVO;
 import hu.psprog.leaflet.service.vo.EntryVO;
+import hu.psprog.leaflet.service.vo.UserVO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,6 +63,21 @@ public class OwnershipEvaluator {
 
         return extractPayload(authentication)
                 .map(jwtPayload -> jwtPayload.getId().equals(id.intValue()) || isAdmin(jwtPayload))
+                .orElse(false);
+    }
+
+    /**
+     * Validates that a user is accessing their own user entry or an admin/editor is accessing user information.
+     *
+     * @param authentication current {@link Authentication} object
+     * @param userVO user VO
+     * @return {@code true} if the given user ID is the same as in the one in the {@link Authentication} object,
+     * or the authenticated user is either an admin or an editor, {@code false} otherwise
+     */
+    public boolean isSelfOrModerator(Authentication authentication, UserVO userVO) {
+
+        return extractPayload(authentication)
+                .map(jwtPayload -> jwtPayload.getId().equals(userVO.getId().intValue()) || isModerator(jwtPayload))
                 .orElse(false);
     }
 

--- a/service/src/test/java/hu/psprog/leaflet/service/security/evaluator/OwnershipEvaluatorTest.java
+++ b/service/src/test/java/hu/psprog/leaflet/service/security/evaluator/OwnershipEvaluatorTest.java
@@ -80,6 +80,20 @@ public class OwnershipEvaluatorTest {
     }
 
     @Test
+    @Parameters(method = "isSelfOrModerator", source = OwnershipEvaluatorParameterProvider.class)
+    public void shouldValidateSelfOrModerator(Long userID, Role role, boolean expectedResult) {
+
+        // given
+        prepareAuthenticationObject(role);
+
+        // when
+        boolean result = ownershipEvaluator.isSelfOrModerator(authentication, UserVO.wrapMinimumVO(userID));
+
+        // then
+        assertThat(result, is(expectedResult));
+    }
+
+    @Test
     @Parameters(method = "isOwnEntryOrAdmin", source = OwnershipEvaluatorParameterProvider.class)
     public void shouldValidateEntry(Role role, Long ownerID, boolean expectedResult) throws ServiceException {
 
@@ -190,6 +204,15 @@ public class OwnershipEvaluatorTest {
             return new Object[] {
                     new Object[] {CURRENT_USER_ID, Role.USER, true},
                     new Object[] {2L, Role.ADMIN, true},
+                    new Object[] {2L, Role.USER, false}
+            };
+        }
+
+        public static Object[] isSelfOrModerator() {
+            return new Object[] {
+                    new Object[] {CURRENT_USER_ID, Role.USER, true},
+                    new Object[] {2L, Role.ADMIN, true},
+                    new Object[] {2L, Role.EDITOR, true},
                     new Object[] {2L, Role.USER, false}
             };
         }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet</artifactId>
-        <version>1.9.2-dev</version>
+        <version>1.9.3-dev</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/web/src/main/java/hu/psprog/leaflet/web/rest/controller/CommentsController.java
+++ b/web/src/main/java/hu/psprog/leaflet/web/rest/controller/CommentsController.java
@@ -6,6 +6,7 @@ import hu.psprog.leaflet.api.rest.request.comment.CommentUpdateRequestModel;
 import hu.psprog.leaflet.api.rest.response.comment.CommentDataModel;
 import hu.psprog.leaflet.api.rest.response.comment.CommentListDataModel;
 import hu.psprog.leaflet.api.rest.response.comment.ExtendedCommentDataModel;
+import hu.psprog.leaflet.api.rest.response.comment.ExtendedCommentListDataModel;
 import hu.psprog.leaflet.api.rest.response.common.BaseBodyDataModel;
 import hu.psprog.leaflet.service.exception.ConstraintViolationException;
 import hu.psprog.leaflet.service.exception.ServiceException;
@@ -137,7 +138,7 @@ public class CommentsController extends BaseController {
     @FillResponse(fill = ResponseFillMode.AJAX)
     @RequestMapping(method = RequestMethod.GET, path = PATH_ALL_COMMENTS_FOR_USER)
     @Timed
-    public ResponseEntity<CommentListDataModel> getPageOfCommentsForUser(
+    public ResponseEntity<ExtendedCommentListDataModel> getPageOfCommentsForUser(
             @PathVariable(PATH_VARIABLE_ID) Long userID,
             @PathVariable(PATH_VARIABLE_PAGE) int page,
             @RequestParam(name = REQUEST_PARAMETER_LIMIT, defaultValue = PAGINATION_DEFAULT_LIMIT) int limit,
@@ -148,7 +149,7 @@ public class CommentsController extends BaseController {
 
         return ResponseEntity
                 .ok()
-                .body(conversionService.convert(comments.getEntitiesOnPage(), CommentListDataModel.class));
+                .body(conversionService.convert(comments.getEntitiesOnPage(), ExtendedCommentListDataModel.class));
     }
 
     /**

--- a/web/src/main/java/hu/psprog/leaflet/web/rest/controller/CommentsController.java
+++ b/web/src/main/java/hu/psprog/leaflet/web/rest/controller/CommentsController.java
@@ -49,6 +49,7 @@ public class CommentsController extends BaseController {
 
     private static final String PATH_PUBLIC_COMMENTS_FOR_ENTRY = "/entry" + PATH_PART_LINK + PATH_PART_PAGE;
     private static final String PATH_ALL_COMMENTS_FOR_ENTRY = "/entry" + PATH_PART_ID + PATH_PART_PAGE + "/all";
+    private static final String PATH_ALL_COMMENTS_FOR_USER = "/user" + PATH_PART_ID + PATH_PART_PAGE;
     private static final String PATH_PERMANENT_DELETION = PATH_PART_ID + "/permanent";
     private static final String REQUESTED_COMMENT_NOT_FOUND = "Requested comment not found";
     private static final String THE_COMMENT_YOU_ARE_LOOKING_FOR_IS_NOT_EXISTING = "The comment you are looking for is not existing";
@@ -115,6 +116,35 @@ public class CommentsController extends BaseController {
             @RequestParam(name = REQUEST_PARAMETER_ORDER_DIRECTION, defaultValue = PAGINATION_DEFAULT_ORDER_DIRECTION) String orderDirection) {
 
         EntityPageVO<CommentVO> comments = commentFacade.getPageOfCommentsForEntry(entryID, page, limit, orderDirection, orderBy);
+
+        return ResponseEntity
+                .ok()
+                .body(conversionService.convert(comments.getEntitiesOnPage(), CommentListDataModel.class));
+    }
+
+    /**
+     * GET /comments/user/{id}/{page}
+     * Retrieves given page of comments for given user (public and non-public comments as well).
+     * Should be used for admin and user profile operations.
+     *
+     * @param userID ID of user to retrieve comments for
+     * @param page page number
+     * @param limit (optional) number of comments on one page; defaults to {@code PAGINATION_DEFAULT_LIMIT}
+     * @param orderBy (optional) order by (CREATED|TITLE); defaults to {@code CREATED}
+     * @param orderDirection (optional) order direction (ASC|DESC); defaults to {@code ASC}
+     * @return list of comments
+     */
+    @FillResponse(fill = ResponseFillMode.AJAX)
+    @RequestMapping(method = RequestMethod.GET, path = PATH_ALL_COMMENTS_FOR_USER)
+    @Timed
+    public ResponseEntity<CommentListDataModel> getPageOfCommentsForUser(
+            @PathVariable(PATH_VARIABLE_ID) Long userID,
+            @PathVariable(PATH_VARIABLE_PAGE) int page,
+            @RequestParam(name = REQUEST_PARAMETER_LIMIT, defaultValue = PAGINATION_DEFAULT_LIMIT) int limit,
+            @RequestParam(name = REQUEST_PARAMETER_ORDER_BY, defaultValue = PAGINATION_DEFAULT_ORDER_BY) String orderBy,
+            @RequestParam(name = REQUEST_PARAMETER_ORDER_DIRECTION, defaultValue = PAGINATION_DEFAULT_ORDER_DIRECTION) String orderDirection) {
+
+        EntityPageVO<CommentVO> comments = commentFacade.getPageOfCommentsForUser(userID, page, limit, orderDirection, orderBy);
 
         return ResponseEntity
                 .ok()

--- a/web/src/main/java/hu/psprog/leaflet/web/rest/conversion/comment/CommentVOToCommentDataModelConverter.java
+++ b/web/src/main/java/hu/psprog/leaflet/web/rest/conversion/comment/CommentVOToCommentDataModelConverter.java
@@ -33,6 +33,7 @@ public class CommentVOToCommentDataModelConverter implements Converter<CommentVO
                         .build())
                 .withContent(source.getContent())
                 .withDeleted(source.isDeleted())
+                .withEnabled(source.isEnabled())
                 .withCreated(dateConverter.convert(source.getCreated()))
                 .withLastModified(dateConverter.convert(source.getLastModified()))
                 .build();

--- a/web/src/main/java/hu/psprog/leaflet/web/rest/conversion/comment/CommentVOToExtendedCommentListDataModelConverter.java
+++ b/web/src/main/java/hu/psprog/leaflet/web/rest/conversion/comment/CommentVOToExtendedCommentListDataModelConverter.java
@@ -1,0 +1,34 @@
+package hu.psprog.leaflet.web.rest.conversion.comment;
+
+import hu.psprog.leaflet.api.rest.response.comment.ExtendedCommentListDataModel;
+import hu.psprog.leaflet.service.vo.CommentVO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Converts a {@link List} of {@link CommentVO} objects to {@link ExtendedCommentListDataModel}.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class CommentVOToExtendedCommentListDataModelConverter implements Converter<List<CommentVO>, ExtendedCommentListDataModel> {
+
+    private CommentVOToExtendedCommentDataModelConverter commentVOToExtendedCommentDataModelConverter;
+
+    @Autowired
+    public CommentVOToExtendedCommentListDataModelConverter(CommentVOToExtendedCommentDataModelConverter commentVOToExtendedCommentDataModelConverter) {
+        this.commentVOToExtendedCommentDataModelConverter = commentVOToExtendedCommentDataModelConverter;
+    }
+
+    @Override
+    public ExtendedCommentListDataModel convert(List<CommentVO> source) {
+
+        ExtendedCommentListDataModel.ExtendedCommentListDataModelBuilder builder = ExtendedCommentListDataModel.getBuilder();
+        source.forEach(commentVO -> builder.withItem(commentVOToExtendedCommentDataModelConverter.convert(commentVO)));
+
+        return builder.build();
+    }
+}

--- a/web/src/test/java/hu/psprog/leaflet/web/rest/controller/CommentsControllerTest.java
+++ b/web/src/test/java/hu/psprog/leaflet/web/rest/controller/CommentsControllerTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verify;
 public class CommentsControllerTest extends AbstractControllerBaseTest {
 
     private static final long ENTRY_ID = 1L;
+    private static final long USER_ID = 2L;
     private static final String ENTRY_LINK = "entry-link";
     private static final long COMMENT_ID = 2L;
     private static final String LOCATION_HEADER = "/comments/" + COMMENT_ID;
@@ -81,6 +82,21 @@ public class CommentsControllerTest extends AbstractControllerBaseTest {
 
         // when
         ResponseEntity<CommentListDataModel> result = controller.getPageOfCommentsForEntry(ENTRY_ID, PAGE, LIMIT, ORDER_BY, DIRECTION);
+
+        // then
+        assertResponse(result, HttpStatus.OK, COMMENT_LIST_DATA_MODEL);
+    }
+
+    @Test
+    public void shouldGetPageOfCommentsForUser() {
+
+        // given
+        given(commentFacade.getPageOfCommentsForUser(USER_ID, PAGE, LIMIT, DIRECTION, ORDER_BY)).willReturn(EntityPageVO.getBuilder()
+                .withEntitiesOnPage(COMMENT_VO_LIST)
+                .build());
+
+        // when
+        ResponseEntity<CommentListDataModel> result = controller.getPageOfCommentsForUser(USER_ID, PAGE, LIMIT, ORDER_BY, DIRECTION);
 
         // then
         assertResponse(result, HttpStatus.OK, COMMENT_LIST_DATA_MODEL);

--- a/web/src/test/java/hu/psprog/leaflet/web/rest/controller/CommentsControllerTest.java
+++ b/web/src/test/java/hu/psprog/leaflet/web/rest/controller/CommentsControllerTest.java
@@ -3,6 +3,7 @@ package hu.psprog.leaflet.web.rest.controller;
 import hu.psprog.leaflet.api.rest.response.comment.CommentDataModel;
 import hu.psprog.leaflet.api.rest.response.comment.CommentListDataModel;
 import hu.psprog.leaflet.api.rest.response.comment.ExtendedCommentDataModel;
+import hu.psprog.leaflet.api.rest.response.comment.ExtendedCommentListDataModel;
 import hu.psprog.leaflet.api.rest.response.common.BaseBodyDataModel;
 import hu.psprog.leaflet.service.exception.ConstraintViolationException;
 import hu.psprog.leaflet.service.exception.ServiceException;
@@ -53,6 +54,7 @@ public class CommentsControllerTest extends AbstractControllerBaseTest {
     public void setup() {
         super.setup();
         given(conversionService.convert(COMMENT_VO_LIST, CommentListDataModel.class)).willReturn(COMMENT_LIST_DATA_MODEL);
+        given(conversionService.convert(COMMENT_VO_LIST, ExtendedCommentListDataModel.class)).willReturn(EXTENDED_COMMENT_LIST_DATA_MODEL);
         given(conversionService.convert(COMMENT_VO, ExtendedCommentDataModel.class)).willReturn(EXTENDED_COMMENT_DATA_MODEL);
         given(conversionService.convert(COMMENT_VO, CommentDataModel.class)).willReturn(COMMENT_DATA_MODEL);
     }
@@ -96,10 +98,10 @@ public class CommentsControllerTest extends AbstractControllerBaseTest {
                 .build());
 
         // when
-        ResponseEntity<CommentListDataModel> result = controller.getPageOfCommentsForUser(USER_ID, PAGE, LIMIT, ORDER_BY, DIRECTION);
+        ResponseEntity<ExtendedCommentListDataModel> result = controller.getPageOfCommentsForUser(USER_ID, PAGE, LIMIT, ORDER_BY, DIRECTION);
 
         // then
-        assertResponse(result, HttpStatus.OK, COMMENT_LIST_DATA_MODEL);
+        assertResponse(result, HttpStatus.OK, EXTENDED_COMMENT_LIST_DATA_MODEL);
     }
 
     @Test

--- a/web/src/test/java/hu/psprog/leaflet/web/rest/conversion/comment/CommentVOToExtendedCommentListDataModelConverterTest.java
+++ b/web/src/test/java/hu/psprog/leaflet/web/rest/conversion/comment/CommentVOToExtendedCommentListDataModelConverterTest.java
@@ -1,0 +1,43 @@
+package hu.psprog.leaflet.web.rest.conversion.comment;
+
+import hu.psprog.leaflet.api.rest.response.comment.ExtendedCommentListDataModel;
+import hu.psprog.leaflet.web.test.ConversionTestObjects;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for {@link CommentVOToExtendedCommentListDataModelConverter}.
+ *
+ * @author Peter Smith
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CommentVOToExtendedCommentListDataModelConverterTest extends ConversionTestObjects {
+
+    @Mock
+    private CommentVOToExtendedCommentDataModelConverter entityConverter;
+
+    @InjectMocks
+    private CommentVOToExtendedCommentListDataModelConverter converter;
+
+    @Test
+    public void shouldConvert() {
+
+        // given
+        given(entityConverter.convert(COMMENT_VO)).willReturn(EXTENDED_COMMENT_DATA_MODEL);
+
+        // when
+        ExtendedCommentListDataModel result = converter.convert(Collections.singletonList(COMMENT_VO));
+
+        // then
+        assertThat(result, equalTo(EXTENDED_COMMENT_LIST_DATA_MODEL));
+    }
+}

--- a/web/src/test/java/hu/psprog/leaflet/web/test/ConversionTestObjects.java
+++ b/web/src/test/java/hu/psprog/leaflet/web/test/ConversionTestObjects.java
@@ -528,6 +528,7 @@ public abstract class ConversionTestObjects {
             .withOwner(USER_DATA_MODEL)
             .withContent(CONTENT)
             .withDeleted(false)
+            .withEnabled(ENABLED)
             .withCreated(ZONED_DATE_TIME_CREATED)
             .withLastModified(ZONED_DATE_TIME_LAST_MODIFIED)
             .build();

--- a/web/src/test/java/hu/psprog/leaflet/web/test/ConversionTestObjects.java
+++ b/web/src/test/java/hu/psprog/leaflet/web/test/ConversionTestObjects.java
@@ -25,6 +25,7 @@ import hu.psprog.leaflet.api.rest.response.category.CategoryListDataModel;
 import hu.psprog.leaflet.api.rest.response.comment.CommentDataModel;
 import hu.psprog.leaflet.api.rest.response.comment.CommentListDataModel;
 import hu.psprog.leaflet.api.rest.response.comment.ExtendedCommentDataModel;
+import hu.psprog.leaflet.api.rest.response.comment.ExtendedCommentListDataModel;
 import hu.psprog.leaflet.api.rest.response.common.ValidationErrorMessageDataModel;
 import hu.psprog.leaflet.api.rest.response.common.ValidationErrorMessageListDataModel;
 import hu.psprog.leaflet.api.rest.response.document.DocumentDataModel;
@@ -546,6 +547,10 @@ public abstract class ConversionTestObjects {
             .withLastModified(ZONED_DATE_TIME_LAST_MODIFIED)
             .withEnabled(ENABLED)
             .withAssociatedEntry(ENTRY_DATA_MODEL)
+            .build();
+
+    protected static final ExtendedCommentListDataModel EXTENDED_COMMENT_LIST_DATA_MODEL = ExtendedCommentListDataModel.getBuilder()
+            .withItem(EXTENDED_COMMENT_DATA_MODEL)
             .build();
 
     protected static final DocumentVO DOCUMENT_VO_WITH_OWNER = DocumentVO.getBuilder()


### PR DESCRIPTION
 - Fixed security requirement for paged comments of user service entry point
 - Added "selfOrModerator" permission
 - Added controller endpoint for paged comments of user operation
 - Updated API to v1.6.3
 - Updated RCP to v.1.5.2
 - Modified CommentVOToCommentDataModelConverter according to API change
 - Added acceptance test case for the new endpoint
 - Aligned/extended unit tests
 - Fixed failing acceptance test cases due to RCP update
 - Updated Bridge to v3.2.2
 - Changed return type of getPageOfCommentsForUser endpoint to ExtendedCommentListDataModel
 - Added new converter
 - Aligned tests