### PR TITLE
LFLT-345 Send confirmation email upon sign-up

### DIFF
--- a/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/mock/MockNotificationService.java
+++ b/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/mock/MockNotificationService.java
@@ -4,6 +4,7 @@ import hu.psprog.leaflet.service.NotificationService;
 import hu.psprog.leaflet.service.mail.domain.CommentNotification;
 import hu.psprog.leaflet.service.mail.domain.PasswordResetRequest;
 import hu.psprog.leaflet.service.mail.domain.PasswordResetSuccess;
+import hu.psprog.leaflet.service.mail.domain.SignUpConfirmation;
 import hu.psprog.leaflet.service.vo.ContactRequestVO;
 
 /**
@@ -17,6 +18,7 @@ public class MockNotificationService implements NotificationService {
     private PasswordResetSuccess passwordResetSuccess;
     private CommentNotification commentNotification;
     private ContactRequestVO contactRequestVO;
+    private SignUpConfirmation signUpConfirmation;
 
     @Override
     public void startupFinished(String version) {
@@ -43,6 +45,11 @@ public class MockNotificationService implements NotificationService {
         this.contactRequestVO = contactRequestVO;
     }
 
+    @Override
+    public void signUpConfirmation(SignUpConfirmation signUpConfirmation) {
+
+    }
+
     public PasswordResetRequest getPasswordResetRequest() {
         return passwordResetRequest;
     }
@@ -59,10 +66,15 @@ public class MockNotificationService implements NotificationService {
         return contactRequestVO;
     }
 
+    public SignUpConfirmation getSignUpConfirmation() {
+        return signUpConfirmation;
+    }
+
     public void reset() {
         passwordResetSuccess = null;
         passwordResetRequest = null;
         commentNotification = null;
         contactRequestVO = null;
+        signUpConfirmation = null;
     }
 }

--- a/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/mock/MockNotificationService.java
+++ b/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/mock/MockNotificationService.java
@@ -47,7 +47,7 @@ public class MockNotificationService implements NotificationService {
 
     @Override
     public void signUpConfirmation(SignUpConfirmation signUpConfirmation) {
-
+        this.signUpConfirmation = signUpConfirmation;
     }
 
     public PasswordResetRequest getPasswordResetRequest() {

--- a/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/suites/UsersControllerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/hu/psprog/leaflet/acceptance/suites/UsersControllerAcceptanceTest.java
@@ -22,6 +22,7 @@ import hu.psprog.leaflet.bridge.client.exception.UnauthorizedAccessException;
 import hu.psprog.leaflet.bridge.service.UserBridgeService;
 import hu.psprog.leaflet.persistence.entity.Role;
 import hu.psprog.leaflet.security.jwt.JWTComponent;
+import hu.psprog.leaflet.service.mail.domain.SignUpConfirmation;
 import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Test;
@@ -366,12 +367,14 @@ public class UsersControllerAcceptanceTest extends AbstractParameterizedBaseTest
 
         // given
         UserInitializeRequestModel userInitializeRequestModel = getControl(CONTROL_USER_REGISTER, UserInitializeRequestModel.class);
+        SignUpConfirmation signUpConfirmation = new SignUpConfirmation(userInitializeRequestModel.getUsername(), userInitializeRequestModel.getEmail());
 
         // when
         ExtendedUserDataModel result = userBridgeService.signUp(userInitializeRequestModel, RECAPTCHA_TOKEN);
 
         // then
         assertCreatedUser(userInitializeRequestModel, result.getId());
+        assertThat(notificationService.getSignUpConfirmation(), equalTo(signUpConfirmation));
     }
 
     @Test(expected = ConflictingRequestException.class)

--- a/acceptance-tests/src/test/resources/application.yml
+++ b/acceptance-tests/src/test/resources/application.yml
@@ -25,6 +25,8 @@ spring:
 files:
   upload:
     storage-path: ${java.io.tmpdir}
+  cache:
+    max-age-in-days: 90
 
 server:
   servlet:

--- a/service/src/main/java/hu/psprog/leaflet/service/NotificationService.java
+++ b/service/src/main/java/hu/psprog/leaflet/service/NotificationService.java
@@ -3,6 +3,7 @@ package hu.psprog.leaflet.service;
 import hu.psprog.leaflet.service.mail.domain.CommentNotification;
 import hu.psprog.leaflet.service.mail.domain.PasswordResetRequest;
 import hu.psprog.leaflet.service.mail.domain.PasswordResetSuccess;
+import hu.psprog.leaflet.service.mail.domain.SignUpConfirmation;
 import hu.psprog.leaflet.service.vo.ContactRequestVO;
 
 /**
@@ -46,4 +47,11 @@ public interface NotificationService {
      * @param contactRequestVO domain object holding required parameters
      */
     void contactRequestReceived(ContactRequestVO contactRequestVO);
+
+    /**
+     * Sends notification about successful sign-up.
+     *
+     * @param signUpConfirmation {@link SignUpConfirmation} domain object holding required parameters
+     */
+    void signUpConfirmation(SignUpConfirmation signUpConfirmation);
 }

--- a/service/src/main/java/hu/psprog/leaflet/service/facade/impl/UserFacadeImpl.java
+++ b/service/src/main/java/hu/psprog/leaflet/service/facade/impl/UserFacadeImpl.java
@@ -1,5 +1,6 @@
 package hu.psprog.leaflet.service.facade.impl;
 
+import hu.psprog.leaflet.service.NotificationService;
 import hu.psprog.leaflet.service.UserAuthenticationService;
 import hu.psprog.leaflet.service.UserService;
 import hu.psprog.leaflet.service.common.Authority;
@@ -7,6 +8,7 @@ import hu.psprog.leaflet.service.exception.EntityNotFoundException;
 import hu.psprog.leaflet.service.exception.ReAuthenticationFailureException;
 import hu.psprog.leaflet.service.exception.ServiceException;
 import hu.psprog.leaflet.service.facade.UserFacade;
+import hu.psprog.leaflet.service.mail.domain.SignUpConfirmation;
 import hu.psprog.leaflet.service.vo.LoginContextVO;
 import hu.psprog.leaflet.service.vo.UserVO;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,12 +29,15 @@ public class UserFacadeImpl implements UserFacade {
     private UserService userService;
     private UserAuthenticationService authenticationService;
     private PasswordEncoder passwordEncoder;
+    private NotificationService notificationService;
 
     @Autowired
-    public UserFacadeImpl(UserService userService, UserAuthenticationService authenticationService, PasswordEncoder passwordEncoder) {
+    public UserFacadeImpl(UserService userService, UserAuthenticationService authenticationService,
+                          PasswordEncoder passwordEncoder, NotificationService notificationService) {
         this.userService = userService;
         this.authenticationService = authenticationService;
         this.passwordEncoder = passwordEncoder;
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -91,7 +96,12 @@ public class UserFacadeImpl implements UserFacade {
 
     @Override
     public Long register(UserVO userData) throws ServiceException {
-        return userService.register(rebuildUserDataWithHashedPassword(userData));
+
+        UserVO rebuiltUserVO = rebuildUserDataWithHashedPassword(userData);
+        Long registeredUserID = userService.register(rebuiltUserVO);
+        notificationService.signUpConfirmation(new SignUpConfirmation(userData.getUsername(), userData.getEmail()));
+
+        return registeredUserID;
     }
 
     @Override

--- a/service/src/main/java/hu/psprog/leaflet/service/impl/EmailBasedNotificationService.java
+++ b/service/src/main/java/hu/psprog/leaflet/service/impl/EmailBasedNotificationService.java
@@ -6,11 +6,13 @@ import hu.psprog.leaflet.service.NotificationService;
 import hu.psprog.leaflet.service.mail.domain.CommentNotification;
 import hu.psprog.leaflet.service.mail.domain.PasswordResetRequest;
 import hu.psprog.leaflet.service.mail.domain.PasswordResetSuccess;
+import hu.psprog.leaflet.service.mail.domain.SignUpConfirmation;
 import hu.psprog.leaflet.service.mail.impl.CommentNotificationMailFactory;
 import hu.psprog.leaflet.service.mail.impl.ContactRequestMailFactory;
 import hu.psprog.leaflet.service.mail.impl.MailFactoryRegistry;
 import hu.psprog.leaflet.service.mail.impl.PasswordResetRequestMailFactory;
 import hu.psprog.leaflet.service.mail.impl.PasswordResetSuccessMailFactory;
+import hu.psprog.leaflet.service.mail.impl.SignUpConfirmationMailFactory;
 import hu.psprog.leaflet.service.mail.impl.SystemStartupMailFactory;
 import hu.psprog.leaflet.service.observer.impl.LoggingMailObserverHandler;
 import hu.psprog.leaflet.service.vo.ContactRequestVO;
@@ -73,6 +75,14 @@ public class EmailBasedNotificationService implements NotificationService {
         Mail mail = mailFactoryRegistry
                 .getFactory(ContactRequestMailFactory.class)
                 .buildMail(contactRequestVO);
+        sendMailAndAttachObserver(mail);
+    }
+
+    @Override
+    public void signUpConfirmation(SignUpConfirmation signUpConfirmation) {
+        Mail mail = mailFactoryRegistry
+                .getFactory(SignUpConfirmationMailFactory.class)
+                .buildMail(signUpConfirmation, signUpConfirmation.getEmail());
         sendMailAndAttachObserver(mail);
     }
 

--- a/service/src/main/java/hu/psprog/leaflet/service/mail/domain/SignUpConfirmation.java
+++ b/service/src/main/java/hu/psprog/leaflet/service/mail/domain/SignUpConfirmation.java
@@ -1,0 +1,59 @@
+package hu.psprog.leaflet.service.mail.domain;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Mail domain for sign-up confirmation mails.
+ *
+ * @author Peter Smith
+ */
+public class SignUpConfirmation {
+
+    private String username;
+    private String email;
+
+    public SignUpConfirmation(String username, String email) {
+        this.username = username;
+        this.email = email;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SignUpConfirmation that = (SignUpConfirmation) o;
+
+        return new EqualsBuilder()
+                .append(username, that.username)
+                .append(email, that.email)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(username)
+                .append(email)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("username", username)
+                .append("email", email)
+                .toString();
+    }
+}

--- a/service/src/main/java/hu/psprog/leaflet/service/mail/impl/SignUpConfirmationMailFactory.java
+++ b/service/src/main/java/hu/psprog/leaflet/service/mail/impl/SignUpConfirmationMailFactory.java
@@ -1,0 +1,52 @@
+package hu.psprog.leaflet.service.mail.impl;
+
+import hu.psprog.leaflet.mail.domain.Mail;
+import hu.psprog.leaflet.service.mail.domain.SignUpConfirmation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * {@link AbstractMailFactory} implementation to generate sign-up confirmation mails.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class SignUpConfirmationMailFactory extends AbstractMailFactory<SignUpConfirmation> {
+
+    private static final String SIGN_UP_CONFIRMATION_MAIL_SUBJECT = "mail.user.signup.confirm.subject";
+    private static final String SIGN_UP_CONFIRMATION_MAIL_TEMPLATE = "signup_confirm.html";
+
+    private static final String GENERATED_AT = "generatedAt";
+    private static final String USERNAME = "username";
+
+    @Autowired
+    public SignUpConfirmationMailFactory(MessageSource messageSource) {
+        super(messageSource);
+    }
+
+    @Override
+    public Mail buildMail(SignUpConfirmation content, String... recipient) {
+
+        Assert.isTrue(Objects.nonNull(recipient) && recipient.length == 1, "Exactly one recipient is required.");
+
+        return Mail.getBuilder()
+                .withRecipient(recipient[0])
+                .withSubject(translateSubject(SIGN_UP_CONFIRMATION_MAIL_SUBJECT))
+                .withTemplate(SIGN_UP_CONFIRMATION_MAIL_TEMPLATE)
+                .withContentMap(createContentMap(content.getUsername()))
+                .build();
+    }
+
+    private Map<String, Object> createContentMap(String username) {
+
+        return Map.of(
+                USERNAME, username,
+                GENERATED_AT, DATE_FORMAT.format(new Date()));
+    }
+}

--- a/service/src/test/java/hu/psprog/leaflet/service/facade/impl/UserFacadeImplTest.java
+++ b/service/src/test/java/hu/psprog/leaflet/service/facade/impl/UserFacadeImplTest.java
@@ -1,11 +1,13 @@
 package hu.psprog.leaflet.service.facade.impl;
 
+import hu.psprog.leaflet.service.NotificationService;
 import hu.psprog.leaflet.service.UserAuthenticationService;
 import hu.psprog.leaflet.service.UserService;
 import hu.psprog.leaflet.service.common.Authority;
 import hu.psprog.leaflet.service.exception.EntityNotFoundException;
 import hu.psprog.leaflet.service.exception.ReAuthenticationFailureException;
 import hu.psprog.leaflet.service.exception.ServiceException;
+import hu.psprog.leaflet.service.mail.domain.SignUpConfirmation;
 import hu.psprog.leaflet.service.vo.LoginContextVO;
 import hu.psprog.leaflet.service.vo.UserVO;
 import junitparams.JUnitParamsRunner;
@@ -58,6 +60,9 @@ public class UserFacadeImplTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private NotificationService notificationService;
 
     @InjectMocks
     private UserFacadeImpl userFacade;
@@ -184,12 +189,14 @@ public class UserFacadeImplTest {
 
         // given
         given(passwordEncoder.encode(PASSWORD)).willReturn(ENCODED_PASSWORD);
+        SignUpConfirmation expectedSignUpConfirmation = new SignUpConfirmation(USER_TO_CREATE.getUsername(), USER_TO_CREATE.getEmail());
 
         // when
         userFacade.register(USER_TO_CREATE);
 
         // then
         verify(userService).register(REBUILT_USER);
+        verify(notificationService).signUpConfirmation(expectedSignUpConfirmation);
     }
 
     @Test

--- a/service/src/test/java/hu/psprog/leaflet/service/impl/EmailBasedNotificationServiceTest.java
+++ b/service/src/test/java/hu/psprog/leaflet/service/impl/EmailBasedNotificationServiceTest.java
@@ -7,11 +7,13 @@ import hu.psprog.leaflet.service.mail.MailFactory;
 import hu.psprog.leaflet.service.mail.domain.CommentNotification;
 import hu.psprog.leaflet.service.mail.domain.PasswordResetRequest;
 import hu.psprog.leaflet.service.mail.domain.PasswordResetSuccess;
+import hu.psprog.leaflet.service.mail.domain.SignUpConfirmation;
 import hu.psprog.leaflet.service.mail.impl.CommentNotificationMailFactory;
 import hu.psprog.leaflet.service.mail.impl.ContactRequestMailFactory;
 import hu.psprog.leaflet.service.mail.impl.MailFactoryRegistry;
 import hu.psprog.leaflet.service.mail.impl.PasswordResetRequestMailFactory;
 import hu.psprog.leaflet.service.mail.impl.PasswordResetSuccessMailFactory;
+import hu.psprog.leaflet.service.mail.impl.SignUpConfirmationMailFactory;
 import hu.psprog.leaflet.service.mail.impl.SystemStartupMailFactory;
 import hu.psprog.leaflet.service.observer.impl.LoggingMailObserverHandler;
 import hu.psprog.leaflet.service.vo.ContactRequestVO;
@@ -62,6 +64,9 @@ public class EmailBasedNotificationServiceTest {
 
     @Mock
     private ContactRequestMailFactory contactRequestMailFactory;
+
+    @Mock
+    private SignUpConfirmationMailFactory signUpConfirmationMailFactory;
 
     @Mock
     private Mail mockMail;
@@ -144,6 +149,21 @@ public class EmailBasedNotificationServiceTest {
 
         // when
         emailBasedNotificationService.contactRequestReceived(contactRequestVO);
+
+        // then
+        assertMailSentAndObserverAttached();
+    }
+
+    @Test
+    public void shouldSendSignUpConfirmation() {
+
+        // given
+        SignUpConfirmation signUpConfirmation = new SignUpConfirmation("username", "email");
+        given(mailFactoryRegistry.getFactory(SignUpConfirmationMailFactory.class)).willReturn(signUpConfirmationMailFactory);
+        given(signUpConfirmationMailFactory.buildMail(signUpConfirmation, signUpConfirmation.getEmail())).willReturn(mockMail);
+
+        // when
+        emailBasedNotificationService.signUpConfirmation(signUpConfirmation);
 
         // then
         assertMailSentAndObserverAttached();

--- a/service/src/test/java/hu/psprog/leaflet/service/mail/impl/SignUpConfirmationMailFactoryTest.java
+++ b/service/src/test/java/hu/psprog/leaflet/service/mail/impl/SignUpConfirmationMailFactoryTest.java
@@ -1,0 +1,81 @@
+package hu.psprog.leaflet.service.mail.impl;
+
+import hu.psprog.leaflet.mail.domain.Mail;
+import hu.psprog.leaflet.service.mail.domain.SignUpConfirmation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.MessageSource;
+
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for {@link SignUpConfirmationMailFactory}.
+ *
+ * @author Peter Smith
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SignUpConfirmationMailFactoryTest {
+
+    private static final String SUBJECT = "mail.user.signup.confirm.subject";
+    private static final String TRANSLATED_SUBJECT = "Successful sign-up";
+    private static final String TEMPLATE = "signup_confirm.html";
+    private static final String RECIPIENT = "test@local.dev";
+
+    private static final String GENERATED_AT = "generatedAt";
+    private static final String USERNAME = "username";
+    private static final SignUpConfirmation SIGN_UP_CONFIRMATION = new SignUpConfirmation(USERNAME, RECIPIENT);
+    private static final Locale FORCED_LOCALE = Locale.ENGLISH;
+
+    @Mock
+    private MessageSource messageSource;
+
+    @InjectMocks
+    private SignUpConfirmationMailFactory signUpConfirmationMailFactory;
+
+    @Test
+    public void shouldBuildMail() {
+
+        // given
+        signUpConfirmationMailFactory.setForcedLocale(FORCED_LOCALE);
+        given(messageSource.getMessage(SUBJECT, null, FORCED_LOCALE)).willReturn(TRANSLATED_SUBJECT);
+
+        // when
+        Mail result = signUpConfirmationMailFactory.buildMail(SIGN_UP_CONFIRMATION, RECIPIENT);
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result.getRecipient(), equalTo(RECIPIENT));
+        assertThat(result.getSubject(), equalTo(TRANSLATED_SUBJECT));
+        assertThat(result.getTemplate(), equalTo(TEMPLATE));
+        assertThat(result.getContentMap().get(USERNAME), equalTo(USERNAME));
+        assertThat(result.getContentMap().get(GENERATED_AT), notNullValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionOnNullRecipient() {
+
+        // given
+        signUpConfirmationMailFactory.buildMail(SIGN_UP_CONFIRMATION);
+
+        // then
+        // exception expected
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionOnMultipleRecipients() {
+
+        // given
+        signUpConfirmationMailFactory.buildMail(SIGN_UP_CONFIRMATION, RECIPIENT, RECIPIENT);
+
+        // then
+        // exception expected
+    }
+}

--- a/web/src/main/resources/mail/signup_confirm.html
+++ b/web/src/main/resources/mail/signup_confirm.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Leaflet System Event Notification</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style type="text/css">
+            body {
+                max-width: 600px;
+                margin: auto;
+                font-family: Calibri;
+            }
+
+            h1 {
+                color: #00638A;
+                border-bottom: 2px solid #eee;
+                padding: 10px 20px;
+            }
+
+            h2 {
+                color: #B0B0B0;
+                padding-left: 30px;
+                font-size: 14px;
+            }
+
+            #content {
+                border-left: 2px solid #eee;
+                margin-left: 30px;
+                margin-top: 30px;
+                padding: 10px 0px 20px 20px;
+            }
+
+            #genDate {
+                margin-top: 60px;
+                font-style: italic;
+                color: #B0B0B0;
+                text-align: right;
+            }
+        </style>
+</head>
+<body>
+<h1 th:text="#{mail.user.signup.confirm.title}">title</h1>
+<h2 th:text="#{mail.user.signup.confirm.sub}">sub</h2>
+<div id="content">
+    <p style="font-weight: bold; margin-bottom: 10px;" th:text="#{mail.user.signup.confirm.greeting(${username})}">greeting</p>
+    <th:block th:text="#{mail.user.signup.confirm.content}">content</th:block>
+    <p id="genDate" th:text="#{mail.user.signup.confirm.timestamp(${generatedAt})}">timestamp</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
 - Created sign-up confirmation mail template
 - Added mail factory implementation for sign-up mails
 - Extended NotificationService
 - Integrated sign-up confirmation mail sending into UserFacade
 - Aligned existing and added new tests