### PR TITLE
LFLT-611 Migrate Leaflet Backend to Java 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   jira: circleci/jira@2.1.0
   jq: circleci/jq@3.0.0
+  gh: circleci/github-cli@2.3.0
 
 # Common parameters for CircleCI build config
 parameters:
@@ -36,21 +37,23 @@ commands:
         default: "rc"
         enum: ["rc", "release"]
     steps:
+      - checkout
       - attach_workspace:
           at: << pipeline.parameters.workspace_dir >>
+      - gh/setup
       - run:
           name: "Publish Release on GitHub"
           command: |
             [[ "<< parameters.release-type >>" = "release" ]] && VERSION_QUALIFIER="-release" || VERSION_QUALIFIER=""
             VERSION=v$(cat << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.version_file >>)$VERSION_QUALIFIER
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.executable_file >>
+            gh release create ${VERSION} --target ${CIRCLE_SHA1} --title ${VERSION} << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.executable_file >>
 
 jobs:
 
   # Leaflet Backend - Build and test application
   build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0
     steps:
       - checkout
       - run:
@@ -101,8 +104,9 @@ jobs:
   # Leaflet Backend - Deploy to production
   deploy:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:21.0
     steps:
+      - checkout
       - attach_workspace:
           at: << pipeline.parameters.workspace_dir >>
       - run:
@@ -158,7 +162,7 @@ jobs:
   # Leaflet Backend - Publish tag (and release) on GitHub for RC versions
   publish-github-rc:
     docker:
-      - image: cibuilds/github:0.10
+      - image: cimg/base:stable
     steps:
       - github_release:
           release-type: rc
@@ -166,7 +170,7 @@ jobs:
   # Leaflet Backend - Publish tag (and release) on GitHub for RELEASE versions
   publish-github-release:
     docker:
-      - image: cibuilds/github:0.10
+      - image: cimg/base:stable
     steps:
       - github_release:
           release-type: release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 
 ARG APP_USER=leaflet
 ARG APP_HOME=/opt/leaflet

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.3.1-dev</version>
+        <version>2.4.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet</artifactId>
-        <version>2.3.1-dev</version>
+        <version>2.4.0-dev</version>
     </parent>
     
     <artifactId>leaflet-persistence</artifactId>

--- a/persistence/src/main/java/hu/psprog/leaflet/persistence/repository/LogicallyDeletableJpaRepository.java
+++ b/persistence/src/main/java/hu/psprog/leaflet/persistence/repository/LogicallyDeletableJpaRepository.java
@@ -25,7 +25,7 @@ public interface LogicallyDeletableJpaRepository<T extends LogicallyDeletableSel
      */
     @Transactional
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE #{#entityName} e SET e.deleted = true, e.lastModified = CURRENT_DATE WHERE e.id = :id")
+    @Query("UPDATE #{#entityName} e SET e.deleted = true, e.lastModified = CURRENT_TIMESTAMP WHERE e.id = :id")
     void markAsDeleted(@Param("id") ID id);
 
     /**
@@ -35,6 +35,6 @@ public interface LogicallyDeletableJpaRepository<T extends LogicallyDeletableSel
      */
     @Transactional
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE #{#entityName} e SET e.deleted = false, e.lastModified = CURRENT_DATE WHERE e.id = :id")
+    @Query("UPDATE #{#entityName} e SET e.deleted = false, e.lastModified = CURRENT_TIMESTAMP WHERE e.id = :id")
     void revertLogicalDeletion(@Param("id") ID id);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <artifactId>leaflet</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.1-dev</version>
+    <version>2.4.0-dev</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>3.2-r2307.1</version>
+        <version>4.0-r2405.1</version>
     </parent>
 
     <modules>
@@ -36,7 +36,7 @@
         <spring.config.location>web/src/main/resources/application.yml</spring.config.location>
         
         <!-- Java environment version -->        
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <!-- Docker build configuration -->
         <!--suppress UnresolvedMavenProperty -->

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet</artifactId>
-        <version>2.3.1-dev</version>
+        <version>2.4.0-dev</version>
     </parent>
     
     <artifactId>leaflet-service</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet</artifactId>
-        <version>2.3.1-dev</version>
+        <version>2.4.0-dev</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/web/src/test/java/hu/psprog/leaflet/web/processor/aspect/ResponseFillerAspectTest.java
+++ b/web/src/test/java/hu/psprog/leaflet/web/processor/aspect/ResponseFillerAspectTest.java
@@ -8,6 +8,7 @@ import hu.psprog.leaflet.api.rest.response.entry.EntryDataModel;
 import hu.psprog.leaflet.api.rest.response.entry.EntryListDataModel;
 import hu.psprog.leaflet.api.rest.response.entry.ExtendedEntryDataModel;
 import hu.psprog.leaflet.service.facade.EntryFacade;
+import hu.psprog.leaflet.service.vo.EntryVO;
 import hu.psprog.leaflet.web.rest.controller.EntriesController;
 import hu.psprog.leaflet.web.rest.filler.ResponseFiller;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -29,6 +30,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -141,7 +144,8 @@ public class ResponseFillerAspectTest {
 
         // given
         prepareAspect(true);
-        given(conversionService.convert(any(), any())).willReturn(EXTENDED_ENTRY_DATA_MODEL);
+        given(entryFacade.findByLink("link")).willReturn(EntryVO.wrapMinimumVO(1L));
+        given(conversionService.convert(any(EntryVO.class), eq(ExtendedEntryDataModel.class))).willReturn(EXTENDED_ENTRY_DATA_MODEL);
 
         // when
         ResponseEntity<?> result = preparePointcut().getEntryByLink("link");
@@ -155,7 +159,7 @@ public class ResponseFillerAspectTest {
 
         // given
         prepareAspect(true);
-        given(conversionService.convert(any(), any())).willReturn(ENTRY_LIST_DATA_MODEL);
+        given(conversionService.convert(anyList(), eq(EntryListDataModel.class))).willReturn(ENTRY_LIST_DATA_MODEL);
 
         // when
         ResponseEntity<?> result = preparePointcut().getAllEntries();


### PR DESCRIPTION
 - Updated Java version to 21
 - Updated Dockerfile base image to Java 21
 - Changed stack base BOM version to 4.0-r2405.1
 - Updated CircleCI JIRA and GitHub integration
 - Bumped application version to 2.4.0-dev